### PR TITLE
✨ feat(config): Add commit history length option for AI context

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,17 +176,18 @@ $ describe-commit [GLOBAL FLAGS] [COMMAND] [COMMAND FLAGS] [dir-path]
 
 Global flags:
 
-| Name                               | Description                                                                                      |               Default value               | Environment variables |
-|------------------------------------|--------------------------------------------------------------------------------------------------|:-----------------------------------------:|:---------------------:|
-| `--config-file="…"` (`-c`)         | path to the configuration file                                                                   | `/depends/on/your-os/describe-commit.yml` |     `CONFIG_FILE`     |
-| `--short-message-only` (`-s`)      | generate a short commit message (subject line) only                                              |                  `false`                  |  `SHORT_MESSAGE_ONLY` |
-| `--enable-emoji` (`-e`)            | enable emoji in the commit message                                                               |                  `false`                  |    `ENABLE_EMOJI`     |
-| `--max-output-tokens="…"`          | maximum number of tokens in the output message                                                   |                   `500`                   |  `MAX_OUTPUT_TOKENS`  |
-| `--ai-provider="…"` (`--ai`)       | AI provider name (gemini/openai)                                                                 |                 `gemini`                  |     `AI_PROVIDER`     |
-| `--gemini-api-key="…"` (`--ga`)    | Gemini API key (https://bit.ly/4jZhiKI, as of February 2025 it's free)                           |                                           |   `GEMINI_API_KEY`    |
-| `--gemini-model-name="…"` (`--gm`) | Gemini model name (https://bit.ly/4i02ARR)                                                       |            `gemini-2.0-flash`             |  `GEMINI_MODEL_NAME`  |
-| `--openai-api-key="…"` (`--oa`)    | OpenAI API key (https://bit.ly/4i03NbR, you need to add funds to your account to access the API) |                                           |   `OPENAI_API_KEY`    |
-| `--openai-model-name="…"` (`--om`) | OpenAI model name (https://bit.ly/4hXCXkL)                                                       |               `gpt-4o-mini`               |  `OPENAI_MODEL_NAME`  |
+| Name                                           | Description                                                                                            |               Default value               |  Environment variables  |
+|------------------------------------------------|--------------------------------------------------------------------------------------------------------|:-----------------------------------------:|:-----------------------:|
+| `--config-file="…"` (`-c`)                     | path to the configuration file                                                                         | `/depends/on/your-os/describe-commit.yml` |      `CONFIG_FILE`      |
+| `--short-message-only` (`-s`)                  | generate a short commit message (subject line) only                                                    |                  `false`                  |  `SHORT_MESSAGE_ONLY`   |
+| `--commit-history-length="…"` (`--cl`, `--hl`) | number of previous commits from the Git history to consider as context for the AI model (0 = disabled) |                   `20`                    | `COMMIT_HISTORY_LENGTH` |
+| `--enable-emoji` (`-e`)                        | enable emoji in the commit message                                                                     |                  `false`                  |     `ENABLE_EMOJI`      |
+| `--max-output-tokens="…"`                      | maximum number of tokens in the output message                                                         |                   `500`                   |   `MAX_OUTPUT_TOKENS`   |
+| `--ai-provider="…"` (`--ai`)                   | AI provider name (gemini/openai)                                                                       |                 `gemini`                  |      `AI_PROVIDER`      |
+| `--gemini-api-key="…"` (`--ga`)                | Gemini API key (https://bit.ly/4jZhiKI, as of February 2025 it's free)                                 |                                           |    `GEMINI_API_KEY`     |
+| `--gemini-model-name="…"` (`--gm`)             | Gemini model name (https://bit.ly/4i02ARR)                                                             |            `gemini-2.0-flash`             |   `GEMINI_MODEL_NAME`   |
+| `--openai-api-key="…"` (`--oa`)                | OpenAI API key (https://bit.ly/4i03NbR, you need to add funds to your account to access the API)       |                                           |    `OPENAI_API_KEY`     |
+| `--openai-model-name="…"` (`--om`)             | OpenAI model name (https://bit.ly/4hXCXkL)                                                             |               `gpt-4o-mini`               |   `OPENAI_MODEL_NAME`   |
 
 <!--/GENERATED:CLI_DOCS-->
 

--- a/describe-commit.yml
+++ b/describe-commit.yml
@@ -12,6 +12,11 @@
 # @type {boolean}
 shortMessageOnly: false
 
+# How many previous commits from the Git history should be considered as context for the AI model?
+# Set to 0 to disable this feature.
+# @type {integer}
+commitHistoryLength: 15
+
 # Enable emoji in the commit message
 # @type {boolean}
 enableEmoji: false

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require (
 	github.com/urfave/cli-docs/v3 v3.0.0-alpha6
 	github.com/urfave/cli/v3 v3.0.0-beta1
+	golang.org/x/sync v0.11.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/urfave/cli-docs/v3 v3.0.0-alpha6 h1:w/l/N0xw1rO/aHRIGXJ0lDwwYFOzilup1
 github.com/urfave/cli-docs/v3 v3.0.0-alpha6/go.mod h1:p7Z4lg8FSTrPB9GTaNyTrK3ygffHZcK3w0cU2VE+mzU=
 github.com/urfave/cli/v3 v3.0.0-beta1 h1:6DTaaUarcM0wX7qj5Hcvs+5Dm3dyUTBbEwIWAjcw9Zg=
 github.com/urfave/cli/v3 v3.0.0-beta1/go.mod h1:FnIeEMYu+ko8zP1F9Ypr3xkZMIDqW3DR92yUtY39q1Y=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -21,27 +21,35 @@ func TestGeneratePrompt(t *testing.T) {
 				ai.WithEmoji(false),
 			},
 			wantContains: []string{
-				"Role", "acting as a Git",
-				"Task", "git diff --staged", "convert it", "well-structured **SINGLE** Git commit message",
+				// role
+				"Role", "Git commit messages",
+
+				// task
+				"Task", "well-structured **SINGLE** Git commit", "based on the provided input",
+
+				// input
+				"Input", "will receive", "git diff", "git log",
+
+				// output
+				"Output", "commit message in plain text without wrapping",
+
+				// guidelines
 				"Guidelines",
-				"Conventional Commit",
-				"`<type>(<scope>): <message>`", "fix(auth): Resolve",
-				"Commit Message Structure",
-				"Focus on summarizing", "Vague messages like", "Use present tense",
-				"The first line should follow the Conventional Commit format",
-				"Keep commit messages clean",
-				"without period at the end",
-				"Commit Body",
-				"add a detailed description in bullet points",
-				"Explain additional context",
-				"Include a **summary** and a list",
-				"Avoid excessive detail",
-				"Don't start it with \"This commit\"",
-				"Security", "Never include sensitive data",
+				"Format", "`<type>(<scope>): <message>`", "`<type>`", "`<scope>`", "`<message>`",
+				"Commit Message Structure", "Summarize what was changed", "Use present tense",
+				"Commit Body", "Start with a single-line summary", "Exclude the provided diff", "add a detailed description",
+				"Example", "feat(api): Add rate-limiting to endpoints", "Implemented rate-limiting", "Enforces request limits",
+
+				// security
+				"Security", "Exclude sensitive data", "or code snippets",
+
+				// instructions
+				"Instructions for the AI", "Analyze the provided", "Synthesize this information",
 			},
 			wantNot: []string{
-				"<emoji>", "♻️",
-				"Summarize all changes in a single",
+				// guidelines
+				"<emoji>", "`<emoji>`", "🐛", "✨", "📝", "🚀", "✅", "♻️", "⬆️", "🔧", "🌐", "💡",
+				"Focus on the primary purpose", "Summarize all changes in a single", "Explain why the changes were made",
 			},
 		},
 		"long with emoji": {
@@ -50,31 +58,36 @@ func TestGeneratePrompt(t *testing.T) {
 				ai.WithEmoji(true),
 			},
 			wantContains: []string{
-				"Role", "acting as a Git",
-				"Task", "git diff --staged", "convert it", "well-structured **SINGLE** Git commit message",
+				// role
+				"Role", "Git commit messages",
+
+				// task
+				"Task", "well-structured **SINGLE** Git commit", "based on the provided input",
+
+				// input
+				"Input", "will receive", "git diff", "git log",
+
+				// output
+				"Output", "commit message in plain text without wrapping",
+
+				// guidelines
 				"Guidelines",
-				"Conventional Commit",
-				"`<emoji> <type>(<scope>): <message>`", "🐛 fix(auth): Resolve",
-				"Focus on the primary purpose of the commit",
-				"Summarize all changes in a single",
-				"Explain why the changes were made",
-				"Security", "Never include sensitive data",
+				"Format", "`<emoji> <type>(<scope>): <message>`", "`<emoji>`", "`<type>`", "`<scope>`", "`<message>`",
+				"🐛", "✨", "📝", "🚀", "✅", "♻️", "⬆️", "🔧", "🌐", "💡",
+				"Example", "✨ feat(api): Add rate-limiting to endpoints",
+				"Focus on the primary purpose", "Summarize all changes in a single", "Explain why the changes were made",
+
+				// security
+				"Security", "Exclude sensitive data", "or code snippets",
+
+				// instructions
+				"Instructions for the AI", "Analyze the provided", "Synthesize this information",
 			},
 			wantNot: []string{
-				"`<type>(<scope>): <message>`",
-				"Commit Message Structure",
-				"Focus on summarizing",
-				"Vague messages like",
-				"Use present tense",
-				"The first line should follow the Conventional Commit format",
-				"Keep commit messages clean",
-				"without period at the end",
-				"Commit Body",
-				"add a detailed description in bullet points",
-				"Explain additional context",
-				"Include a **summary** and a list",
-				"Avoid excessive detail",
-				"Don't start it with \"This commit\"",
+				// guidelines
+				"Commit Message Structure", "Summarize what was changed", "Use present tense",
+				"Commit Body", "Start with a single-line summary", "Exclude the provided diff", "add a detailed description",
+				"Implemented rate-limiting", "Enforces request limits",
 			},
 		},
 	} {

--- a/internal/ai/providers.go
+++ b/internal/ai/providers.go
@@ -9,7 +9,7 @@ type (
 	// Provider is an interface for AI providers.
 	Provider interface {
 		// Query the remote provider for the given string.
-		Query(context.Context, string, ...Option) (*Response, error)
+		Query(_ context.Context, changes, commits string, _ ...Option) (*Response, error)
 	}
 
 	// Response is a response from an AI provider.

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -41,6 +41,14 @@ var shortMessageOnlyFlag = cli.BoolFlag{
 	OnlyOnce: true,
 }
 
+var commitHistoryLengthFlag = cli.IntFlag{
+	Name:    "commit-history-length",
+	Aliases: []string{"cl", "hl"},
+	Usage:   "number of previous commits from the Git history to consider as context for the AI model (0 = disabled)",
+	Sources: cli.EnvVars("COMMIT_HISTORY_LENGTH"),
+	Value:   20, //nolint:mnd
+}
+
 var enableEmojiFlag = cli.BoolFlag{
 	Name:     "enable-emoji",
 	Aliases:  []string{"e"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,12 +12,13 @@ import (
 // Config is used to unmarshal the configuration file content.
 type ( // pointers are used to distinguish between unset and set values (nil = unset)
 	Config struct {
-		ShortMessageOnly *bool   `yaml:"shortMessageOnly"`
-		EnableEmoji      *bool   `yaml:"enableEmoji"`
-		AIProviderName   *string `yaml:"aiProvider"`
-		MaxOutputTokens  *int64  `yaml:"maxOutputTokens"`
-		Gemini           *Gemini `yaml:"gemini"`
-		OpenAI           *OpenAI `yaml:"openai"`
+		ShortMessageOnly    *bool   `yaml:"shortMessageOnly"`
+		CommitHistoryLength *int64  `yaml:"commitHistoryLength"`
+		EnableEmoji         *bool   `yaml:"enableEmoji"`
+		AIProviderName      *string `yaml:"aiProvider"`
+		MaxOutputTokens     *int64  `yaml:"maxOutputTokens"`
+		Gemini              *Gemini `yaml:"gemini"`
+		OpenAI              *OpenAI `yaml:"openai"`
 	}
 
 	Gemini struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,7 @@ func TestConfig_FromFile(t *testing.T) {
 		"full config": {
 			giveContent: `
 shortMessageOnly: true
+commitHistoryLength: 312312
 enableEmoji: false
 maxOutputTokens: 123123123
 aiProvider: foobar
@@ -36,6 +37,7 @@ openai:
   modelName: <openai-model-name>`,
 			wantStruct: func() (c config.Config) {
 				c.ShortMessageOnly = toPtr(true)
+				c.CommitHistoryLength = toPtr[int64](312312)
 				c.EnableEmoji = toPtr(false)
 				c.MaxOutputTokens = toPtr[int64](123123123)
 				c.AIProviderName = toPtr("foobar")

--- a/internal/git/bin.go
+++ b/internal/git/bin.go
@@ -1,0 +1,23 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// binPath returns the path to the git binary.
+func binPath() (string, error) {
+	var name = "git"
+
+	if runtime.GOOS == "windows" {
+		name = "git.exe"
+	}
+
+	p, err := exec.LookPath(name)
+	if err != nil {
+		return "", fmt.Errorf("%s not found: %w", name, err)
+	}
+
+	return p, nil
+}

--- a/internal/git/errors.go
+++ b/internal/git/errors.go
@@ -1,0 +1,22 @@
+package git
+
+import "strings"
+
+// stdErrToString converts the standard error output into a more readable format (mot much, but anyway).
+func stdErrToString(stdErr string) string {
+	if len(stdErr) == 0 {
+		return ""
+	}
+
+	var lines = strings.Split(stdErr, "\n")
+
+	// remove empty lines
+	for i := 0; i < len(lines); i++ {
+		if len(strings.TrimSpace(lines[i])) == 0 {
+			lines = append(lines[:i], lines[i+1:]...)
+			i--
+		}
+	}
+
+	return strings.Join(lines, "; ")
+}

--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -1,0 +1,43 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// Log returns the commit log of the repository limited to the specified number of commits.
+func Log(ctx context.Context, dirPath string, len int) (string, error) {
+	// ensure git is installed and available to run
+	gitFilePath, lookErr := binPath()
+	if lookErr != nil {
+		return "", lookErr
+	}
+
+	// get the log
+	var cmd = exec.CommandContext(ctx, gitFilePath, "log",
+		"--format=%s",
+		fmt.Sprintf("--max-count=%d", len),
+		"--no-color",
+	)
+
+	cmd.Dir = dirPath
+
+	var stdOut, stdErr bytes.Buffer
+
+	stdOut.Grow(1024 * 2) //nolint:mnd // 2KB
+
+	cmd.Stdout = &stdOut
+	cmd.Stderr = &stdErr
+
+	if err := cmd.Run(); err != nil {
+		if stdErr.Len() > 0 {
+			err = fmt.Errorf("%s: %w", stdErrToString(stdErr.String()), err)
+		}
+
+		return "", fmt.Errorf("git log failed: %w", err)
+	}
+
+	return stdOut.String(), nil
+}


### PR DESCRIPTION
Introduced a new command-line option to specify the number of previous commits to consider as context for the AI model. This enhances the AI's ability to generate relevant commit messages by providing it with more contextual information from the commit history. The default value is set to 20, and it can be adjusted via the configuration file or command-line flags.

- Added `--commit-history-length` flag to CLI
- Updated configuration file to support new option
- Modified AI provider interfaces to accept commit history context
