### PR TITLE
🔧 chore(git): Update environment variables for git commands

### DIFF
--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -6,13 +6,13 @@ import (
 )
 
 const (
-	ditDiffBegin, gitDiffEnd = "[---GIT-DIFF-BEGIN---]", "[---GIT-DIFF-END---]"
+	gitDiffBegin, gitDiffEnd = "[---GIT-DIFF-BEGIN---]", "[---GIT-DIFF-END---]"
 	gitLogBegin, gitLogEnd   = "[---GIT-LOG-BEGIN---]", "[---GIT-LOG-END---]"
 )
 
 // wrapChanges wraps the provided diff output between the specified markers (to help the AI identify the changes).
 func wrapChanges(diff string) string {
-	return fmt.Sprintf("%s\n%s\n%s", ditDiffBegin, diff, gitDiffEnd)
+	return fmt.Sprintf("%s\n%s\n%s", gitDiffBegin, diff, gitDiffEnd)
 }
 
 // wrapCommits wraps the provided log output between the specified markers (to help the AI too).
@@ -48,7 +48,7 @@ func GeneratePrompt(opts ...Option) string { //nolint:funlen
 		b.WriteString("You will receive:\n")
 		b.WriteString(fmt.Sprintf(
 			"1. The output of `git diff`, showing the staged changes, is wrapped between `%s` and `%s`.\n",
-			ditDiffBegin, gitDiffEnd,
+			gitDiffBegin, gitDiffEnd,
 		))
 		b.WriteString(fmt.Sprintf(
 			"2. The output of `git log`, presenting recent commit history, is wrapped between `%s` and `%s`.\n",

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -37,6 +37,11 @@ func Diff(ctx context.Context, dirPath string) (string, error) {
 	)
 
 	cmd.Dir = dirPath
+	cmd.Env = []string{
+		"LC_ALL=C", "LANG=C", // forces the system to use the "C" (POSIX) locale, English-based output with no localization
+		"NO_COLOR=1",            // disables colored output
+		"GIT_CONFIG_NOSYSTEM=1", // do not use the system-wide configuration file
+	}
 
 	var stdOut, stdErr bytes.Buffer
 

--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -23,6 +23,11 @@ func Log(ctx context.Context, dirPath string, len int) (string, error) {
 	)
 
 	cmd.Dir = dirPath
+	cmd.Env = []string{
+		"LC_ALL=C", "LANG=C", // forces the system to use the "C" (POSIX) locale, English-based output with no localization
+		"NO_COLOR=1",            // disables colored output
+		"GIT_CONFIG_NOSYSTEM=1", // do not use the system-wide configuration file
+	}
 
 	var stdOut, stdErr bytes.Buffer
 


### PR DESCRIPTION
Set environment variables in git diff and log commands to enforce POSIX locale, disable colored output, and avoid using the system-wide configuration file. This improves consistency and reduces potential issues across different environments.
