### PR TITLE
chore(ci): Migrate to Goreleaser for build and release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,37 +11,11 @@ jobs:
   build-app:
     name: Build the app
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [linux, darwin, windows]
-        arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
-      - {uses: gacts/github-slug@v1, id: slug}
-      - id: values
-        run: |
-          echo "bin-name=describe-commit-${{ matrix.os }}-${{ matrix.arch }}`[ ${{ matrix.os }} = 'windows' ] && echo '.exe'`" >> $GITHUB_OUTPUT
       - {uses: actions/setup-go@v5, with: {go-version-file: go.mod}}
-      - run: go generate -skip readme ./...
-      - env:
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-          CGO_ENABLED: 0
-          LDFLAGS: -s -w -X gh.tarampamp.am/describe-commit/internal/version.version=${{ steps.slug.outputs.version-semantic }}
-        run: go build -trimpath -ldflags "$LDFLAGS" -o "./${{ steps.values.outputs.bin-name }}" ./cmd/describe-commit/
-      - uses: actions/upload-artifact@v4
-        with:
-          name: describe-commit-${{ matrix.os }}-${{ matrix.arch }}
-          path: ./${{ steps.values.outputs.bin-name }}
-          if-no-files-found: error
-          retention-days: 1
-      - uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./${{ steps.values.outputs.bin-name }}
-          asset_name: ${{ steps.values.outputs.bin-name }}
-          tag: ${{ github.ref }}
+      - uses: goreleaser/goreleaser-action@v6
+        env: {OWNER: '${{ github.actor }}'}
 
   build-docker-image:
     name: Build the docker image

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ describe-commit.yml
 ## Temp dirs & trash
 /temp
 /tmp
+/dist
 .DS_Store
 /go.work*
 *.cache

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+before:
+  hooks: [go generate -skip readme ./...]
+
+builds: # https://goreleaser.com/customization/builds/go/
+  - main: ./cmd/describe-commit
+    binary: describe-commit
+    goos: [windows, darwin, linux]
+    goarch: [amd64, arm, arm64]
+    env: [CGO_ENABLED=0]
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags: [-trimpath]
+    ldflags: ['-s -w -X gh.tarampamp.am/describe-commit/internal/version.version={{ .Version }}']
+
+release: # https://goreleaser.com/customization/release/
+  draft: true # if true, will not auto-publish the release
+
+archives: # https://goreleaser.com/customization/archive/
+  - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+    formats: [gz, binary]
+    files: [none*]
+    format_overrides: [{goos: windows, formats: [zip, binary]}]
+
+checksum: # https://goreleaser.com/customization/checksum/
+  algorithm: sha256
+  split: false # if true, will create one checksum file for each artifact
+  name_template: checksums.txt
+
+nfpms: # https://goreleaser.com/customization/nfpm/
+  - file_name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+    maintainer: '{{ .Env.OWNER }}'
+    description: CLI tool that leverages AI to generate commit messages based on changes made in a Git repository
+    bindir: /usr/local/bin
+    formats: [apk, deb, rpm, archlinux]
+    dependencies: [git]


### PR DESCRIPTION
Replaced the existing GitHub Actions workflow with Goreleaser to streamline the build and release process for the CLI tool. This change simplifies the configuration and enhances the ability to manage builds across multiple platforms. Additionally, updated the .gitignore to exclude the new distribution directory.
