### PR TITLE
feat: Add AUR support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ needs.values.outputs.owner }}
           DOCKER_IMAGES: ${{ needs.values.outputs.docker-images }}
+          AUR_GIT_USERNAME: ${{ secrets.AUR_GIT_USERNAME }}
+          AUR_GIT_EMAIL: ${{ secrets.AUR_GIT_EMAIL }}
+          AUR_SSH_PRIVATE: ${{ secrets.AUR_SSH_PRIVATE }}
         with: {args: release --clean}
       - uses: actions/attest-build-provenance@v2
         with: {subject-checksums: ./dist/checksums.txt}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
       - {uses: gacts/github-slug@v1, id: slug}
       - {id: version, run: 'echo "out=${{ steps.slug.outputs.version-semantic }}" > "$GITHUB_OUTPUT"'}
-      - {id: owner,   run: 'echo "out=${{ github.actor }}" > "$GITHUB_OUTPUT"'}
+      - {id: owner,   run: 'echo "out=${{ github.repository_owner }}" > "$GITHUB_OUTPUT"'}
       - {id: repo,    run: 'echo "out=${{ github.event.repository.name }}" > "$GITHUB_OUTPUT"'}
       - id: docker-images
         env:
-          GH_IMAGE: ghcr.io/${{ steps.owner.outputs.out }}/${{ steps.repo.outputs.out }}
+          GH_IMAGE: ghcr.io/${{ github.repository }}
           VERSION: ${{ steps.version.outputs.out }}
           MAJOR: ${{ steps.slug.outputs.version-major }}
           MINOR: ${{ steps.slug.outputs.version-minor }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,10 +33,16 @@ release: # https://goreleaser.com/customization/release/
     {{ end }}
 
 archives: # https://goreleaser.com/customization/archive/
-  - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+  - id: default
+    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
     formats: [gz, binary]
     files: [none*]
     format_overrides: [{goos: windows, formats: [zip, binary]}]
+  - id: aur
+    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+    formats: [tar.gz]
+    files: [LICENSE]
+    format_overrides: [{goos: windows, formats: [none]}]
 
 checksum: # https://goreleaser.com/customization/checksum/
   algorithm: sha256
@@ -51,5 +57,53 @@ nfpms: # https://goreleaser.com/customization/nfpm/
     formats: [apk, deb, rpm, archlinux]
     dependencies: [git]
 
-# TODO(@jetexe): Add AUR support
-#aurs: # https://goreleaser.com/customization/aur/
+aurs: # https://goreleaser.com/customization/aur/
+  - name: describe-commit-bin
+    ids: [aur]
+    homepage: 'https://github.com/tarampampam/describe-commit'
+    description: CLI tool that leverages AI to generate commit messages based on changes made in a Git repository
+    maintainers:
+      - tarampampam <murmur at cats dot rulez>
+      - jetexe <aur at jetexe dot net>
+    license: MIT
+    private_key: '{{ .Env.AUR_SSH_PRIVATE }}'
+    git_url: ssh://aur@aur.archlinux.org/describe-commit-bin.git
+    provides: [describe-commit]
+    conflicts: [describe-commit]
+    depends: [git]
+    commit_author:
+      name: '{{ .Env.AUR_GIT_USERNAME }}'
+      email: '{{ .Env.AUR_GIT_EMAIL }}'
+
+# Source archives for AUR sources package
+source: # https://goreleaser.com/customization/source/
+  enabled: true
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_sources'
+
+aur_sources: # https://goreleaser.com/customization/aursources/
+  - name: describe-commit
+    homepage: 'https://github.com/tarampampam/describe-commit'
+    description: CLI tool that leverages AI to generate commit messages based on changes made in a Git repository
+    maintainers:
+      - tarampampam <murmur at cats dot rulez>
+      - jetexe <aur at jetexe dot net>
+    license: MIT
+    private_key: '{{ .Env.AUR_SSH_PRIVATE }}'
+    git_url: ssh://aur@aur.archlinux.org/describe-commit.git
+    depends: [git]
+    makedepends:
+      - go
+    prepare: |-
+      go mod download
+    build: |-
+      go generate -skip readme ./...
+
+      CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags "-s -w -X gh.tarampamp.am/describe-commit/internal/version.version=${pkgver}" \
+        -o ./describe-commit \
+        ./cmd/describe-commit/
+    package: install -Dm755 "./{{ .ProjectName }}" "$pkgdir/usr/bin/{{ .ProjectName }}"
+    commit_author:
+      name: '{{ .Env.AUR_GIT_USERNAME }}'
+      email: '{{ .Env.AUR_GIT_EMAIL }}'

--- a/README.md
+++ b/README.md
@@ -128,15 +128,21 @@ $EDITOR /etc/apk/repositories # remove the line with the repository
 
 ### 📦 AUR (Arch Linux)
 
+There are three packages available in the AUR:
+
+- Build from source: [describe-commit](https://aur.archlinux.org/packages/describe-commit)
+- Precompiled: [describe-commit-bin](https://aur.archlinux.org/packages/describe-commit-bin)
+- Unstable: [describe-commit-git](https://aur.archlinux.org/packages/describe-commit-git)
+
 ```shell
-# TODO(@jetexe): Add instructions for the AUR package
+pamac build describe-commit
 ```
 
 <details>
   <summary>Uninstalling</summary>
 
 ```shell
-# TODO(@jetexe): Add instructions for the AUR package
+pacman -Rs describe-commit
 ```
 
 </details>


### PR DESCRIPTION
Adds support for building and publishing to the Arch User Repository (AUR) with two packages: `describe-commit` (build from source) and `describe-commit-bin` (prebuilt binary).


## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of my code
- [x] I have added comments to my code, especially in areas that may be difficult to understand
- [ ] I have written unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
