### PR TITLE
feat(ai): Add OpenRouter support for AI provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Currently, it supports the following AI providers:
 
 - [OpenAI ChatGPT](https://openai.com/chatgpt/overview/)
 - [Google Gemini](https://deepmind.google/technologies/gemini/)
+- [OpenRouter](https://openrouter.ai/)
 
 It also allows users to select the desired model for content generating.
 
@@ -358,11 +359,13 @@ Options:
    --commit-history-length="…", --cl="…", --hl="…"  Number of previous commits from the Git history (0 = disabled) (default: 20) [$COMMIT_HISTORY_LENGTH]
    --enable-emoji, -e                               Enable emoji in the commit message [$ENABLE_EMOJI]
    --max-output-tokens="…"                          Maximum number of tokens in the output message (default: 500) [$MAX_OUTPUT_TOKENS]
-   --ai-provider="…", --ai="…"                      AI provider name (gemini|openai) (default: gemini) [$AI_PROVIDER]
+   --ai-provider="…", --ai="…"                      AI provider name (gemini|openai|openrouter) (default: gemini) [$AI_PROVIDER]
    --gemini-api-key="…", --ga="…"                   Gemini API key (https://bit.ly/4jZhiKI, as of February 2025 it's free) [$GEMINI_API_KEY]
    --gemini-model-name="…", --gm="…"                Gemini model name (https://bit.ly/4i02ARR) (default: gemini-2.0-flash) [$GEMINI_MODEL_NAME]
    --openai-api-key="…", --oa="…"                   OpenAI API key (https://bit.ly/4i03NbR, you need to add funds to your account) [$OPENAI_API_KEY]
    --openai-model-name="…", --om="…"                OpenAI model name (https://bit.ly/4hXCXkL) (default: gpt-4o-mini) [$OPENAI_MODEL_NAME]
+   --openrouter-api-key="…", --ora="…"              OpenRouter API key (https://bit.ly/4hU1yY1) [$OPENROUTER_API_KEY]
+   --openrouter-model-name="…", --orm="…"           OpenRouter model name (https://bit.ly/4ktktuG) (default: nvidia/llama-3.1-nemotron-70b-instruct:free) [$OPENROUTER_MODEL_NAME]
    --help, -h                                       Show help
    --version, -v                                    Print the version
 ```

--- a/describe-commit.example.yml
+++ b/describe-commit.example.yml
@@ -26,7 +26,7 @@ enableEmoji: false
 maxOutputTokens: 500
 
 # AI provider to use
-# @enum {gemini|openai}
+# @enum {gemini|openai|openrouter}
 aiProvider: gemini
 
 # Gemini provider configuration
@@ -48,3 +48,13 @@ openai:
   # OpenAI model name (https://bit.ly/4hXCXkL)
   # @type {string}
   #modelName: <openai-model-name>
+
+# OpenRouter provider configuration
+openrouter:
+  # OpenRouter API key (issue your own at https://bit.ly/4hU1yY1)
+  # @type {string}
+  apiKey: <openrouter-api-key>
+
+  # OpenAI model name (https://bit.ly/4ktktuG)
+  # @type {string}
+  #modelName: <openrouter-model-name>

--- a/internal/ai/openrouter.go
+++ b/internal/ai/openrouter.go
@@ -11,36 +11,37 @@ import (
 	"time"
 )
 
-type OpenAI struct {
+// OpenRouter is a provider for the OpenRouter API.
+type OpenRouter struct {
 	httpClient        httpClient
 	apiKey, modelName string
 }
 
-var _ Provider = (*OpenAI)(nil)
+var _ Provider = (*OpenRouter)(nil) // ensure the interface is implemented
 
 type (
-	openaiOptions struct {
+	openRouterOptions struct {
 		HttpClient httpClient
 	}
 
-	// OpenAIOption allows to customize the OpenAI provider.
-	OpenAIOption func(*openaiOptions)
+	// OpenRouterOption allows to customize the OpenRouter provider.
+	OpenRouterOption func(*openRouterOptions)
 )
 
-// WithOpenAIHttpClient sets the HTTP client for the OpenAI provider.
-func WithOpenAIHttpClient(c httpClient) OpenAIOption {
-	return func(o *openaiOptions) { o.HttpClient = c }
+// WithOpenRouterHttpClient sets the HTTP client for the OpenRouter provider.
+func WithOpenRouterHttpClient(c httpClient) OpenRouterOption {
+	return func(o *openRouterOptions) { o.HttpClient = c }
 }
 
-// NewOpenAI creates a new OpenAI provider.
-func NewOpenAI(apiKey, model string, opt ...OpenAIOption) *OpenAI {
-	var opts openaiOptions
+// NewOpenRouter creates a new OpenRouter provider.
+func NewOpenRouter(apiKey, model string, opt ...OpenRouterOption) *OpenRouter {
+	var opts openRouterOptions
 
 	for _, o := range opt {
 		o(&opts)
 	}
 
-	var p = OpenAI{
+	var p = OpenRouter{
 		httpClient: opts.HttpClient,
 		apiKey:     apiKey,
 		modelName:  model,
@@ -56,7 +57,7 @@ func NewOpenAI(apiKey, model string, opt ...OpenAIOption) *OpenAI {
 	return &p
 }
 
-func (p *OpenAI) Query( //nolint:dupl
+func (p *OpenRouter) Query( //nolint:dupl
 	ctx context.Context,
 	changes, commits string,
 	opts ...Option,
@@ -95,7 +96,7 @@ func (p *OpenAI) Query( //nolint:dupl
 		var parts = strings.Split(answer, "\n")
 
 		if len(parts) == 0 {
-			return nil, errors.New("no response from the OpenAI API")
+			return nil, errors.New("no response from the OpenRouter API")
 		}
 
 		return &Response{Prompt: instructions, Answer: parts[0]}, nil
@@ -104,8 +105,8 @@ func (p *OpenAI) Query( //nolint:dupl
 	return &Response{Prompt: instructions, Answer: answer}, nil
 }
 
-// newRequest creates a new HTTP request for the OpenAI API.
-func (p *OpenAI) newRequest(
+// newRequest creates a new HTTP request for the OpenRouter API.
+func (p *OpenRouter) newRequest(
 	ctx context.Context,
 	instructions, changes, commits string,
 	o options,
@@ -115,22 +116,20 @@ func (p *OpenAI) newRequest(
 		Content string `json:"content"`
 	}
 
-	// https://platform.openai.com/docs/api-reference/chat
+	// https://openrouter.ai/docs/api-reference/parameters
 	j, jErr := json.Marshal(struct {
-		Model               string    `json:"model"`
-		Messages            []message `json:"messages"`
-		Store               bool      `json:"store"`
-		Temperature         float64   `json:"temperature"`
-		TopP                float64   `json:"top_p"`
-		HowMany             int       `json:"n"` // How many chat completion choices to generate for each input message
-		MaxCompletionTokens int64     `json:"max_completion_tokens"`
+		Model       string    `json:"model"`
+		Messages    []message `json:"messages"`
+		Temperature float64   `json:"temperature"`
+		TopP        float64   `json:"top_p"`
+		HowMany     int       `json:"n"` // How many chat completion choices to generate for each input message
+		MaxTokens   int64     `json:"max_tokens"`
 	}{
-		Model:               p.modelName,
-		Store:               false,
-		Temperature:         0.1, //nolint:mnd
-		TopP:                0.1, //nolint:mnd
-		HowMany:             1,
-		MaxCompletionTokens: o.MaxOutputTokens,
+		Model:       p.modelName,
+		Temperature: 0.1, //nolint:mnd
+		TopP:        0.1, //nolint:mnd
+		HowMany:     1,
+		MaxTokens:   o.MaxOutputTokens,
 		Messages: []message{
 			{Role: "system", Content: instructions},
 			{Role: "user", Content: wrapChanges(changes)},
@@ -141,10 +140,9 @@ func (p *OpenAI) newRequest(
 		return nil, jErr
 	}
 
-	// https://ai.google.dev/gemini-api/docs/text-generation?lang=rest
 	req, rErr := http.NewRequestWithContext(ctx,
 		http.MethodPost,
-		"https://api.openai.com/v1/chat/completions",
+		"https://openrouter.ai/api/v1/chat/completions",
 		bytes.NewReader(j),
 	)
 	if rErr != nil {
@@ -157,8 +155,8 @@ func (p *OpenAI) newRequest(
 	return req, nil
 }
 
-// responseToError converts the response from the OpenAI API to an error.
-func (p *OpenAI) responseToError(resp *http.Response) error {
+// responseToError converts the response from the OpenRouter API to an error.
+func (p *OpenRouter) responseToError(resp *http.Response) error {
 	var response struct {
 		Error struct {
 			Message string `json:"message"`
@@ -167,19 +165,19 @@ func (p *OpenAI) responseToError(resp *http.Response) error {
 
 	if err := json.NewDecoder(resp.Body).Decode(&response); err == nil && response.Error.Message != "" {
 		return fmt.Errorf(
-			"OpenAI API error: %s (status code: %d)",
+			"OpenRouter API error: %s (status code: %d)",
 			response.Error.Message, resp.StatusCode,
 		)
 	}
 
 	return fmt.Errorf(
-		"unexpected OpenAI API response status code: %d (%s)",
+		"unexpected OpenRouter API response status code: %d (%s)",
 		resp.StatusCode, http.StatusText(resp.StatusCode),
 	)
 }
 
-// parseResponse parses the response from the OpenAI API.
-func (p *OpenAI) parseResponse(resp *http.Response) (string, error) {
+// parseResponse parses the response from the OpenRouter API.
+func (p *OpenRouter) parseResponse(resp *http.Response) (string, error) {
 	var answer struct {
 		Choices []struct {
 			Message struct {
@@ -192,15 +190,15 @@ func (p *OpenAI) parseResponse(resp *http.Response) (string, error) {
 		return "", dErr
 	}
 
-	if len(answer.Choices) == 0 {
-		return "", errors.New("no response from the OpenAI API")
+	if len(answer.Choices) == 0 || len(answer.Choices[0].Message.Content) == 0 {
+		return "", errors.New("no content found")
 	}
 
 	var texts = make([]string, 0, len(answer.Choices))
 
 	for _, choice := range answer.Choices {
-		if choice.Message.Content != "" {
-			texts = append(texts, choice.Message.Content)
+		if text := choice.Message.Content; text != "" {
+			texts = append(texts, text)
 		}
 	}
 

--- a/internal/ai/providers.go
+++ b/internal/ai/providers.go
@@ -28,13 +28,14 @@ type httpClient interface {
 
 // Do not forget to update the [SupportedProviders] function if you add or remove providers.
 const (
-	ProviderGemini = "gemini"
-	ProviderOpenAI = "openai"
+	ProviderGemini     = "gemini"
+	ProviderOpenAI     = "openai"
+	ProviderOpenRouter = "openrouter"
 )
 
 // SupportedProviders returns a list of supported AI providers.
 func SupportedProviders() []string {
-	return []string{ProviderGemini, ProviderOpenAI}
+	return []string{ProviderGemini, ProviderOpenAI, ProviderOpenRouter}
 }
 
 // IsProviderSupported checks if the given provider is supported.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -110,6 +110,18 @@ func NewApp(name string) *App { //nolint:funlen
 			EnvVars: []string{"OPENAI_MODEL_NAME"},
 			Default: app.opt.Providers.OpenAI.ModelName,
 		}
+		openRouterApiKey = cmd.Flag[string]{
+			Names:   []string{"openrouter-api-key", "ora"},
+			Usage:   "OpenRouter API key (https://bit.ly/4hU1yY1)",
+			EnvVars: []string{"OPENROUTER_API_KEY"},
+			Default: app.opt.Providers.OpenRouter.ApiKey,
+		}
+		openRouterModelName = cmd.Flag[string]{
+			Names:   []string{"openrouter-model-name", "orm"},
+			Usage:   "OpenRouter model name (https://bit.ly/4ktktuG)",
+			EnvVars: []string{"OPENROUTER_MODEL_NAME"},
+			Default: app.opt.Providers.OpenRouter.ModelName,
+		}
 	)
 
 	app.cmd.Flags = []cmd.Flagger{
@@ -123,6 +135,8 @@ func NewApp(name string) *App { //nolint:funlen
 		&geminiModelName,
 		&openAIApiKey,
 		&openAIModelName,
+		&openRouterApiKey,
+		&openRouterModelName,
 	}
 
 	app.cmd.Action = func(ctx context.Context, c *cmd.Command, args []string) error {
@@ -147,6 +161,8 @@ func NewApp(name string) *App { //nolint:funlen
 			setIfFlagIsSet(&app.opt.Providers.Gemini.ModelName, geminiModelName)
 			setIfFlagIsSet(&app.opt.Providers.OpenAI.ApiKey, openAIApiKey)
 			setIfFlagIsSet(&app.opt.Providers.OpenAI.ModelName, openAIModelName)
+			setIfFlagIsSet(&app.opt.Providers.OpenRouter.ApiKey, openRouterApiKey)
+			setIfFlagIsSet(&app.opt.Providers.OpenRouter.ModelName, openRouterModelName)
 		}
 
 		if err := app.opt.Validate(); err != nil {
@@ -230,6 +246,11 @@ func (a *App) run(ctx context.Context, workingDir string) error { //nolint:funle
 		provider = ai.NewOpenAI(
 			a.opt.Providers.OpenAI.ApiKey,
 			a.opt.Providers.OpenAI.ModelName,
+		)
+	case ai.ProviderOpenRouter:
+		provider = ai.NewOpenRouter(
+			a.opt.Providers.OpenRouter.ApiKey,
+			a.opt.Providers.OpenRouter.ModelName,
 		)
 	default:
 		return fmt.Errorf("unsupported AI provider: %s", a.opt.AIProviderName)

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -19,8 +19,9 @@ type options struct {
 	AIProviderName      string
 
 	Providers struct {
-		Gemini struct{ ApiKey, ModelName string }
-		OpenAI struct{ ApiKey, ModelName string }
+		Gemini     struct{ ApiKey, ModelName string }
+		OpenAI     struct{ ApiKey, ModelName string }
+		OpenRouter struct{ ApiKey, ModelName string }
 	}
 }
 
@@ -33,6 +34,7 @@ func newOptionsWithDefaults() options {
 
 	opt.Providers.Gemini.ModelName = "gemini-2.0-flash"
 	opt.Providers.OpenAI.ModelName = "gpt-4o-mini"
+	opt.Providers.OpenRouter.ModelName = "nvidia/llama-3.1-nemotron-70b-instruct:free"
 
 	return opt
 }
@@ -78,6 +80,11 @@ func (o *options) UpdateFromConfigFile(filePath []string) error {
 		setIfSourceNotNil(&o.Providers.OpenAI.ModelName, sub.ModelName)
 	}
 
+	if sub := cfg.OpenRouter; sub != nil {
+		setIfSourceNotNil(&o.Providers.OpenRouter.ApiKey, sub.ApiKey)
+		setIfSourceNotNil(&o.Providers.OpenRouter.ModelName, sub.ModelName)
+	}
+
 	return nil
 }
 
@@ -116,6 +123,16 @@ func (o *options) Validate() error {
 
 		if o.Providers.OpenAI.ModelName == "" {
 			return errors.New("OpenAI model name is required")
+		}
+	}
+
+	if o.AIProviderName == ai.ProviderOpenRouter {
+		if o.Providers.OpenRouter.ApiKey == "" {
+			return errors.New("OpenRouter API key is required")
+		}
+
+		if o.Providers.OpenRouter.ModelName == "" {
+			return errors.New("OpenRouter model name is required")
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,13 +13,14 @@ type (
 	// Config is used to unmarshal the configuration file content.
 	Config struct {
 		// pointers are used to distinguish between unset and set values (nil = unset)
-		ShortMessageOnly    *bool   `yaml:"shortMessageOnly"`
-		CommitHistoryLength *int64  `yaml:"commitHistoryLength"`
-		EnableEmoji         *bool   `yaml:"enableEmoji"`
-		AIProviderName      *string `yaml:"aiProvider"`
-		MaxOutputTokens     *int64  `yaml:"maxOutputTokens"`
-		Gemini              *Gemini `yaml:"gemini"`
-		OpenAI              *OpenAI `yaml:"openai"`
+		ShortMessageOnly    *bool       `yaml:"shortMessageOnly"`
+		CommitHistoryLength *int64      `yaml:"commitHistoryLength"`
+		EnableEmoji         *bool       `yaml:"enableEmoji"`
+		AIProviderName      *string     `yaml:"aiProvider"`
+		MaxOutputTokens     *int64      `yaml:"maxOutputTokens"`
+		Gemini              *Gemini     `yaml:"gemini"`
+		OpenAI              *OpenAI     `yaml:"openai"`
+		OpenRouter          *OpenRouter `yaml:"openrouter"`
 	}
 
 	Gemini struct {
@@ -28,6 +29,11 @@ type (
 	}
 
 	OpenAI struct {
+		ApiKey    *string `yaml:"apiKey"`
+		ModelName *string `yaml:"modelName"`
+	}
+
+	OpenRouter struct {
 		ApiKey    *string `yaml:"apiKey"`
 		ModelName *string `yaml:"modelName"`
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,7 +34,10 @@ gemini:
   modelName: <gemini-model-name>
 openai:
   apiKey: <openai-api-key>
-  modelName: <openai-model-name>`,
+  modelName: <openai-model-name>
+openrouter:
+  apiKey: <openrouter-api-key>
+  modelName: <openrouter-model-name>`,
 			wantStruct: func() (c config.Config) {
 				c.ShortMessageOnly = toPtr(true)
 				c.CommitHistoryLength = toPtr[int64](312312)
@@ -48,6 +51,10 @@ openai:
 				c.OpenAI = &config.OpenAI{
 					ApiKey:    toPtr("<openai-api-key>"),
 					ModelName: toPtr("<openai-model-name>"),
+				}
+				c.OpenRouter = &config.OpenRouter{
+					ApiKey:    toPtr("<openrouter-api-key>"),
+					ModelName: toPtr("<openrouter-model-name>"),
 				}
 
 				return


### PR DESCRIPTION
Introduced OpenRouter as a new AI provider, allowing users to utilize its capabilities alongside existing providers. Updated configuration options and CLI flags to accommodate the new provider, enhancing flexibility in AI model selection.
