### PR TITLE
 feat(ai): Add Anthropic Claude support as AI provider ✨

### DIFF
--- a/describe-commit.example.yml
+++ b/describe-commit.example.yml
@@ -58,3 +58,17 @@ openrouter:
   # OpenAI model name (https://bit.ly/4ktktuG)
   # @type {string}
   #modelName: <openrouter-model-name>
+
+# Anthropic provider configuration
+anhtropic:
+  # Anthropic API key
+  # @type {string}
+  apiKey: <anhtropic-api-key>
+
+  # Anthropic model name
+  # @type {string}
+  #modelName: <anthropic-model-name>
+
+  # Anthropic version
+  # @type {string}
+  #version: <anthropic-version>

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -1,0 +1,212 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type AnthropicAPIResponse struct {
+	Content    		[]AnthropicContent 	`json:"content"`
+}
+
+type AnthropicContent struct {
+	Type   string  `json:"type"`
+	Text   string  `json:"text,omitempty"`
+}
+
+
+type Anthropic struct {
+	httpClient        httpClient
+	apiKey, modelName, anthropicVersion string
+}
+
+var _ Provider = (*Anthropic)(nil)
+
+type (
+	AnthropicOptions struct {
+		HttpClient httpClient
+	}
+
+	// AnthropicOption allows to customize the Anthropic provider.
+	AnthropicOption func(*AnthropicOptions)
+)
+
+// WithAnthropicHttpClient sets the HTTP client for the Anthropic provider.
+func WithAnthropicHttpClient(c httpClient) AnthropicOption {
+	return func(o *AnthropicOptions) { o.HttpClient = c }
+}
+
+// NewAnthropic creates a new Anthropic provider.
+func NewAnthropic(apiKey, model string, version string, opt ...AnthropicOption) *Anthropic {
+	var opts AnthropicOptions
+
+	for _, o := range opt {
+		o(&opts)
+	}
+
+	var p = Anthropic{
+		httpClient: opts.HttpClient,
+		apiKey:     apiKey,
+		modelName:  model,
+		anthropicVersion: version,
+	}
+
+	if p.httpClient == nil { // set default HTTP client
+		p.httpClient = &http.Client{
+			Timeout:   60 * time.Second,                         //nolint:mnd
+			Transport: &http.Transport{ForceAttemptHTTP2: true}, // use HTTP/2 (why not?)
+		}
+	}
+
+	return &p
+}
+
+func (p *Anthropic) Query( //nolint:dupl
+	ctx context.Context,
+	changes, commits string,
+	opts ...Option,
+) (*Response, error) {
+	var (
+		opt          = options{}.Apply(opts...)
+		instructions = GeneratePrompt(opts...)
+	)
+
+	if opt.MaxOutputTokens == 0 {
+		opt.MaxOutputTokens = defaultMaxOutputTokens // set default value
+	}
+
+	req, rErr := p.newRequest(ctx, instructions, changes, commits, opt)
+	if rErr != nil {
+		return nil, rErr
+	}
+
+	resp, rErr := p.httpClient.Do(req)
+	if rErr != nil {
+		return nil, rErr
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.responseToError(resp)
+	}
+
+	answer, aErr := p.parseResponse(resp)
+	if aErr != nil {
+		return nil, aErr
+	}
+
+	if opt.ShortMessageOnly {
+		var parts = strings.Split(answer, "\n")
+
+		if len(parts) == 0 {
+			return nil, errors.New("no response from the Anthropic API")
+		}
+
+		return &Response{Prompt: instructions, Answer: parts[0]}, nil
+	}
+
+	return &Response{Prompt: instructions, Answer: answer}, nil
+}
+
+// newRequest creates a new HTTP request for the Anthropic API.
+func (p *Anthropic) newRequest(
+	ctx context.Context,
+	instructions, changes, commits string,
+	o options,
+) (*http.Request, error) {
+	type message struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+
+	// https://docs.anthropic.com/en/api/messages
+	j, jErr := json.Marshal(struct {
+		Model               string    `json:"model"`
+		Messages            []message `json:"messages"`
+		Stream				bool	  `json:"stream"`
+		Temperature         float64   `json:"temperature"`
+		TopP                float64   `json:"top_p"`
+		MaxTokens 			int64     `json:"max_tokens"`
+		System				string	  `json:"system"`
+	}{
+		Model:               p.modelName,
+		Stream:              false,
+		System:				 instructions,
+		Temperature:         0.1, //nolint:mnd
+		TopP:                0.1, //nolint:mnd
+		MaxTokens: 			 o.MaxOutputTokens,
+		Messages: []message{
+			{Role: "user", Content: wrapChanges(changes)},
+			{Role: "user", Content: wrapCommits(commits)},
+		},
+	})
+	if jErr != nil {
+		return nil, jErr
+	}
+
+	// https://ai.google.dev/gemini-api/docs/text-generation?lang=rest
+	req, rErr := http.NewRequestWithContext(ctx,
+		http.MethodPost,
+		"https://api.anthropic.com/v1/messages",
+		bytes.NewReader(j),
+	)
+	if rErr != nil {
+		return nil, rErr
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", p.apiKey)
+	req.Header.Set("anthropic-version", p.anthropicVersion)
+
+	return req, nil
+}
+
+// responseToError converts the response from the Anthropic API to an error.
+func (p *Anthropic) responseToError(resp *http.Response) error {
+	var response struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err == nil && response.Error.Message != "" {
+		return fmt.Errorf(
+			"Anthropic API error: %s (status code: %d)",
+			response.Error.Message, resp.StatusCode,
+		)
+	}
+
+	return fmt.Errorf(
+		"unexpected Anthropic API response status code: %d (%s)",
+		resp.StatusCode, http.StatusText(resp.StatusCode),
+	)
+}
+
+// parseResponse parses the response from the Anthropic API.
+func (p *Anthropic) parseResponse(resp *http.Response) (string, error) {
+	var answer AnthropicAPIResponse
+	if dErr := json.NewDecoder(resp.Body).Decode(&answer); dErr != nil {
+		return "", dErr
+	}
+
+	if len(answer.Content) == 0 {
+		return "", errors.New("no response from the Anthropic API")
+	}
+
+	var texts = make([]string, 0, len(answer.Content))
+
+	for _, message := range answer.Content {
+		if message.Text != "" {
+			texts = append(texts, message.Text)
+		}
+	}
+
+	return strings.Trim(strings.Join(texts, "\n"), "\n\t "), nil
+}

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -12,17 +12,16 @@ import (
 )
 
 type AnthropicAPIResponse struct {
-	Content    		[]AnthropicContent 	`json:"content"`
+	Content []AnthropicContent `json:"content"`
 }
 
 type AnthropicContent struct {
-	Type   string  `json:"type"`
-	Text   string  `json:"text,omitempty"`
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
 }
 
-
 type Anthropic struct {
-	httpClient        httpClient
+	httpClient                          httpClient
 	apiKey, modelName, anthropicVersion string
 }
 
@@ -51,9 +50,9 @@ func NewAnthropic(apiKey, model string, version string, opt ...AnthropicOption) 
 	}
 
 	var p = Anthropic{
-		httpClient: opts.HttpClient,
-		apiKey:     apiKey,
-		modelName:  model,
+		httpClient:       opts.HttpClient,
+		apiKey:           apiKey,
+		modelName:        model,
 		anthropicVersion: version,
 	}
 
@@ -128,20 +127,20 @@ func (p *Anthropic) newRequest(
 
 	// https://docs.anthropic.com/en/api/messages
 	j, jErr := json.Marshal(struct {
-		Model               string    `json:"model"`
-		Messages            []message `json:"messages"`
-		Stream				bool	  `json:"stream"`
-		Temperature         float64   `json:"temperature"`
-		TopP                float64   `json:"top_p"`
-		MaxTokens 			int64     `json:"max_tokens"`
-		System				string	  `json:"system"`
+		Model       string    `json:"model"`
+		Messages    []message `json:"messages"`
+		Stream      bool      `json:"stream"`
+		Temperature float64   `json:"temperature"`
+		TopP        float64   `json:"top_p"`
+		MaxTokens   int64     `json:"max_tokens"`
+		System      string    `json:"system"`
 	}{
-		Model:               p.modelName,
-		Stream:              false,
-		System:				 instructions,
-		Temperature:         0.1, //nolint:mnd
-		TopP:                0.1, //nolint:mnd
-		MaxTokens: 			 o.MaxOutputTokens,
+		Model:       p.modelName,
+		Stream:      false,
+		System:      instructions,
+		Temperature: 0.1, //nolint:mnd
+		TopP:        0.1, //nolint:mnd
+		MaxTokens:   o.MaxOutputTokens,
 		Messages: []message{
 			{Role: "user", Content: wrapChanges(changes)},
 			{Role: "user", Content: wrapCommits(commits)},

--- a/internal/ai/providers.go
+++ b/internal/ai/providers.go
@@ -31,11 +31,12 @@ const (
 	ProviderGemini     = "gemini"
 	ProviderOpenAI     = "openai"
 	ProviderOpenRouter = "openrouter"
+	ProviderAnthropic  = "anthropic"
 )
 
 // SupportedProviders returns a list of supported AI providers.
 func SupportedProviders() []string {
-	return []string{ProviderGemini, ProviderOpenAI, ProviderOpenRouter}
+	return []string{ProviderGemini, ProviderOpenAI, ProviderOpenRouter, ProviderAnthropic}
 }
 
 // IsProviderSupported checks if the given provider is supported.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -122,6 +122,24 @@ func NewApp(name string) *App { //nolint:funlen
 			EnvVars: []string{"OPENROUTER_MODEL_NAME"},
 			Default: app.opt.Providers.OpenRouter.ModelName,
 		}
+		anthropicApiKey = cmd.Flag[string]{
+			Names:   []string{"anthropic-api-key", "ana"},
+			Usage:   "Anthropic API key (https://bit.ly/4hU1yY1)",
+			EnvVars: []string{"ANTHROPIC_API_KEY"},
+			Default: app.opt.Providers.Anthropic.ApiKey,
+		}
+		anthropicModelName = cmd.Flag[string]{
+			Names:   []string{"anthropic-model-name", "anm"},
+			Usage:   "Anthropic model name (https://bit.ly/4ktktuG)",
+			EnvVars: []string{"ANTHROPIC_MODEL_NAME"},
+			Default: app.opt.Providers.Anthropic.ModelName,
+		}
+		anthropicVersion = cmd.Flag[string]{
+			Names:   []string{"anthropic-version", "anv"},
+			Usage:   "Anthropic version",
+			EnvVars: []string{"ANTHROPIC_VERSION"},
+			Default: app.opt.Providers.Anthropic.Version,
+		}
 	)
 
 	app.cmd.Flags = []cmd.Flagger{
@@ -137,6 +155,9 @@ func NewApp(name string) *App { //nolint:funlen
 		&openAIModelName,
 		&openRouterApiKey,
 		&openRouterModelName,
+		&anthropicApiKey,
+		&anthropicModelName,
+		&anthropicVersion,
 	}
 
 	app.cmd.Action = func(ctx context.Context, c *cmd.Command, args []string) error {
@@ -163,6 +184,8 @@ func NewApp(name string) *App { //nolint:funlen
 			setIfFlagIsSet(&app.opt.Providers.OpenAI.ModelName, openAIModelName)
 			setIfFlagIsSet(&app.opt.Providers.OpenRouter.ApiKey, openRouterApiKey)
 			setIfFlagIsSet(&app.opt.Providers.OpenRouter.ModelName, openRouterModelName)
+			setIfFlagIsSet(&app.opt.Providers.Anthropic.ApiKey, anthropicApiKey)
+			setIfFlagIsSet(&app.opt.Providers.Anthropic.ModelName, anthropicModelName)
 		}
 
 		if err := app.opt.Validate(); err != nil {
@@ -251,6 +274,12 @@ func (a *App) run(ctx context.Context, workingDir string) error { //nolint:funle
 		provider = ai.NewOpenRouter(
 			a.opt.Providers.OpenRouter.ApiKey,
 			a.opt.Providers.OpenRouter.ModelName,
+		)
+	case ai.ProviderAnthropic:
+		provider = ai.NewAnthropic(
+			a.opt.Providers.Anthropic.ApiKey,
+			a.opt.Providers.Anthropic.ModelName,
+			a.opt.Providers.Anthropic.Version,
 		)
 	default:
 		return fmt.Errorf("unsupported AI provider: %s", a.opt.AIProviderName)

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -33,11 +33,11 @@ func newOptionsWithDefaults() options {
 		AIProviderName:      ai.ProviderGemini, // due to its free
 	}
 
-	opt.Providers.Gemini.ModelName 		= "gemini-2.0-flash"
-	opt.Providers.OpenAI.ModelName 		= "gpt-4o-mini"
-	opt.Providers.OpenRouter.ModelName 	= "nvidia/llama-3.1-nemotron-70b-instruct:free"
-	opt.Providers.Anthropic.ModelName 	= "claude-3-7-sonnet-20250219"
-	opt.Providers.Anthropic.Version 	= "2023-06-01"
+	opt.Providers.Gemini.ModelName = "gemini-2.0-flash"
+	opt.Providers.OpenAI.ModelName = "gpt-4o-mini"
+	opt.Providers.OpenRouter.ModelName = "nvidia/llama-3.1-nemotron-70b-instruct:free"
+	opt.Providers.Anthropic.ModelName = "claude-3-7-sonnet-20250219"
+	opt.Providers.Anthropic.Version = "2023-06-01"
 
 	return opt
 }

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -22,6 +22,7 @@ type options struct {
 		Gemini     struct{ ApiKey, ModelName string }
 		OpenAI     struct{ ApiKey, ModelName string }
 		OpenRouter struct{ ApiKey, ModelName string }
+		Anthropic  struct{ ApiKey, ModelName, Version string }
 	}
 }
 
@@ -32,9 +33,11 @@ func newOptionsWithDefaults() options {
 		AIProviderName:      ai.ProviderGemini, // due to its free
 	}
 
-	opt.Providers.Gemini.ModelName = "gemini-2.0-flash"
-	opt.Providers.OpenAI.ModelName = "gpt-4o-mini"
-	opt.Providers.OpenRouter.ModelName = "nvidia/llama-3.1-nemotron-70b-instruct:free"
+	opt.Providers.Gemini.ModelName 		= "gemini-2.0-flash"
+	opt.Providers.OpenAI.ModelName 		= "gpt-4o-mini"
+	opt.Providers.OpenRouter.ModelName 	= "nvidia/llama-3.1-nemotron-70b-instruct:free"
+	opt.Providers.Anthropic.ModelName 	= "claude-3-7-sonnet-20250219"
+	opt.Providers.Anthropic.Version 	= "2023-06-01"
 
 	return opt
 }
@@ -133,6 +136,16 @@ func (o *options) Validate() error {
 
 		if o.Providers.OpenRouter.ModelName == "" {
 			return errors.New("OpenRouter model name is required")
+		}
+	}
+
+	if o.AIProviderName == ai.ProviderAnthropic {
+		if o.Providers.Anthropic.ApiKey == "" {
+			return errors.New("Anthropic API key is required")
+		}
+
+		if o.Providers.Anthropic.ModelName == "" {
+			return errors.New("Anthropic model name is required")
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type (
 		Gemini              *Gemini     `yaml:"gemini"`
 		OpenAI              *OpenAI     `yaml:"openai"`
 		OpenRouter          *OpenRouter `yaml:"openrouter"`
+		Anthropic           *Anthropic  `yaml:"anthropic"`
 	}
 
 	Gemini struct {
@@ -34,6 +35,11 @@ type (
 	}
 
 	OpenRouter struct {
+		ApiKey    *string `yaml:"apiKey"`
+		ModelName *string `yaml:"modelName"`
+	}
+
+	Anthropic struct {
 		ApiKey    *string `yaml:"apiKey"`
 		ModelName *string `yaml:"modelName"`
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type (
 	Anthropic struct {
 		ApiKey    *string `yaml:"apiKey"`
 		ModelName *string `yaml:"modelName"`
+		Version   *string `yaml:"version"`
 	}
 )
 


### PR DESCRIPTION
Implement Anthropic Claude as a new AI provider option for generating commit messages. The integration includes:

- Complete Anthropic API client implementation
- Configuration options for API key, model name, and API version
- CLI flags and environment variables for Anthropic settings
- Default configuration with Claude 3.7 Sonnet model
- Validation for required Anthropic credentials

## Description

<!--

Hey there! First off, I want to express my gratitude for your contribution. Thank you so much! 🤩

Please provide a brief description of what this PR accomplishes and the problem it solves. Additionally,
include any relevant context or motivation behind the changes. If there are any dependencies required
for this change, list them here.

-->

Fixes # (issue)

## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of my code
- [] I have added comments to my code, especially in areas that may be difficult to understand
- [] I have written unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
